### PR TITLE
GNOME 48 Support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "description": "Automatically change theme styles when dark mode is enabled or disabled.",
   "version": 4,
   "uuid": "dm-theme-changer@lynixx01.github.com",
-  "shell-version": ["46", "47"],
+  "shell-version": ["46", "47", "48"],
   "url": "https://github.com/Lynixx01/DmThemeChanger",
   "settings-schema": "org.gnome.shell.extensions.dmthemechanger"
 }


### PR DESCRIPTION
Enable GNOME 48. Works on GNOME 48 without any problems (so far)

Thanks for this extension - very helpful!